### PR TITLE
Added Bento Debian directory for Live Build + Info

### DIFF
--- a/debian/live-build/Info.txt
+++ b/debian/live-build/Info.txt
@@ -1,0 +1,2 @@
+# This is the Bento Openbox Debian section dedicated to build Bento Debian
+# editions


### PR DESCRIPTION
This is the *live-build* directory dedicated to the sources which will allow building Bento Debian 64 and 32bits editions.
